### PR TITLE
Fix chat username alignment in Owncast 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Well you could use this theme!
 ## How to use
 
 ### Requirements
-- Owncast 0.1.1
-  
-**Note:** A the time of writing, Owncast 0.1.1 has **not** been released yet. You could try using this theme on Owncast 0.1.0, but it'll probably break in all kind of painful ways!
+- Owncast 0.2.*
+
+**Note about Owncast 0.2.\***: Due to changes in the underlying htm lmarkup of the chat, the badges that appear when a user is authenticated or is a moderator cannot be aligned consistently. For this reason, the badges are not presented to the left of the username anymore.
 
 ### Installation
 

--- a/owncast-twitchy.css
+++ b/owncast-twitchy.css
@@ -41,8 +41,7 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     [class*=" ChatUserMessage_repeat"],
     [class^="ChatUserMessage_user"],
     [class*=" ChatUserMessage_user"] {
-        display: inline-block!important;
-        margin-right: 3px;
+        display: inline!important;
     }
 
     [class^="ChatUserMessage_user_"]::after,
@@ -55,9 +54,14 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     [class^="ChatUserMessage_userBadges"],
     [class*=" ChatUserMessage_userBadges"] {
-        margin: 0px 0px 0px -4px !important;
-        float: left;
-        /* Show badges on left of username */
+        margin: 0px !important;
+    }
+
+    [class^="ChatUserBadge_badge_"],
+    [class*=" ChatUserBadge_badge_"] {
+        width: 10px !important;
+        height: 10px !important;
+        margin-left: 2px !important;
     }
 
     [class^="ChatUserMessage_message"] p,


### PR DESCRIPTION
Fix vertical alignment of usernames  relative to the message.
But, badges cannot be consistently aligned when floated left, and move up or down if pushed by emojis or emotes. For this reason, badges have been put back to their original place (to the right).

Closes #2 